### PR TITLE
feat: アートの再設計とスタイルの刷新

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -1,9 +1,10 @@
 // グローバル変数
 let particles = [];
+const palette = ['#4a69bd', '#5e8ac6', '#2c3e50', '#7f8c8d'];
 let settings = {
-    polymer: 70,       // ポリマー性能 (反発力)
-    concentration: 150, // 粒子数
-    energy: 30         // 動きの活発さ
+    polymer: 70,
+    concentration: 150,
+    energy: 30
 };
 
 // UI要素への参照
@@ -12,10 +13,10 @@ let polymerValueSpan, concentrationValueSpan, energyValueSpan;
 
 function setup() {
     let canvasContainer = select('#canvas-container');
-    let canvas = createCanvas(canvasContainer.width, 400);
-    canvas.parent(canvasContainer); // キャンバスをコンテナに配置
+    // canvasのサイズを固定値にして、描画が崩れないようにする
+    let canvas = createCanvas(800, 400);
+    canvas.parent(canvasContainer);
 
-    // UI要素を取得
     polymerSlider = select('#polymerSlider');
     concentrationSlider = select('#concentrationSlider');
     energySlider = select('#energySlider');
@@ -23,12 +24,10 @@ function setup() {
     concentrationValueSpan = select('#concentrationValue');
     energyValueSpan = select('#energyValue');
 
-    // スライダーの初期値を設定オブジェクトに反映
     settings.polymer = polymerSlider.value();
     settings.concentration = concentrationSlider.value();
     settings.energy = energySlider.value();
 
-    // スライダーが操作されたときのイベントリスナー
     polymerSlider.input(() => {
         settings.polymer = polymerSlider.value();
         polymerValueSpan.html(settings.polymer);
@@ -36,110 +35,103 @@ function setup() {
     concentrationSlider.input(() => {
         settings.concentration = concentrationSlider.value();
         concentrationValueSpan.html(settings.concentration);
-        resetParticles(); // 粒子数を変更
     });
     energySlider.input(() => {
         settings.energy = energySlider.value();
         energyValueSpan.html(settings.energy);
     });
-
-    // 最初の粒子群を生成
-    resetParticles();
 }
 
 function draw() {
-    // 軌跡を残すために、少し透明な黒で背景を塗りつぶす
-    background(26, 26, 26, 50);
+    // 新しい背景色と軌跡効果
+    background(253, 251, 247, 80);
+
+    // 粒子の上限数まで、中央から新しい粒子を追加
+    while (particles.length < settings.concentration) {
+        particles.push(new Particle(width / 2, height / 2));
+    }
 
     // 全ての粒子を更新・描画
-    for (let p of particles) {
-        p.calculateForces(particles); // 他の粒子からの力を計算
-        p.update();                 // 位置を更新
-        p.checkEdges();             // 壁との衝突判定
-        p.display();                // 描画
+    // 配列の末尾から処理することで、安全に要素を削除できる
+    for (let i = particles.length - 1; i >= 0; i--) {
+        let p = particles[i];
+        p.calculateForces(particles);
+        p.update();
+        p.display();
+
+        // 寿命が尽きたか、画面外に出た粒子を配列から削除
+        if (p.isDead()) {
+            particles.splice(i, 1);
+        }
     }
 }
-
-// 粒子を再生成する関数
-function resetParticles() {
-    particles = []; // 配列を初期化
-    for (let i = 0; i < settings.concentration; i++) {
-        particles.push(new Particle(random(width), random(height)));
-    }
-}
-
 
 // ===== Particle クラス =====
-// 粒子一つ一つの設計図
 class Particle {
     constructor(x, y) {
         this.pos = createVector(x, y);
-        this.vel = p5.Vector.random2D().mult(random(1, 3));
+        this.vel = p5.Vector.random2D().mult(random(1, 4)); // 爆発的な動き
         this.acc = createVector(0, 0);
-        this.maxSpeed = 3; // 最高速度
-        this.color = color(random(100, 255), random(100, 255), random(100, 255), 200);
-        this.size = random(3, 6);
+        this.maxSpeed = 5;
+
+        let baseColor = color(random(palette));
+        baseColor.setAlpha(255); // 透明度を初期化
+        this.color = baseColor;
+
+        this.size = random(3, 7);
+        this.lifespan = random(150, 300); // 粒子の寿命
     }
 
-    // 他の粒子からの力を計算して蓄積
-    calculateForces(otherParticles) {
-        this.acc.mult(0); // 毎フレーム、加速度をリセット
+    isDead() {
+        return this.lifespan <= 0;
+    }
 
-        // 環境エネルギー（ランダムな動き）
-        let noiseFactor = map(settings.energy, 0, 100, 0, 1);
+    calculateForces(otherParticles) {
+        this.acc.mult(0);
+
+        let noiseFactor = map(settings.energy, 0, 100, 0, 0.5);
         let randomForce = p5.Vector.random2D().mult(noiseFactor);
         this.applyForce(randomForce);
 
-        // 他の粒子との相互作用
         for (let other of otherParticles) {
-            if (other === this) continue; // 自分自身とは計算しない
+            if (other === this) continue;
 
             let d = dist(this.pos.x, this.pos.y, other.pos.x, other.pos.y);
+            let repulsionRadius = map(settings.polymer, 0, 100, 10, 100);
 
-            // 1. 反発力（ポリマーの性能）
-            let repulsionRadius = map(settings.polymer, 0, 100, 5, 80); // ポリマー性能が高いほど、反発する距離が広がる
             if (d > 0 && d < repulsionRadius) {
                 let repulsion = p5.Vector.sub(this.pos, other.pos);
                 repulsion.normalize();
-                repulsion.div(d * 0.5); // 近いほど強く反発
+                repulsion.div(d * 0.2);
                 this.applyForce(repulsion);
-            }
-
-            // 2. 引き合う力（凝集力） - 反発半径の外側で働く
-            let attractionRadius = 100;
-            if (d > repulsionRadius && d < attractionRadius) {
-                let attraction = p5.Vector.sub(other.pos, this.pos);
-                attraction.normalize();
-                attraction.mult(0.05); // 弱い引力
-                this.applyForce(attraction);
             }
         }
     }
-    
-    // 力（ベクトル）を加速度に加える
+
     applyForce(force) {
         this.acc.add(force);
     }
 
-    // 物理法則に従って位置を更新
     update() {
         this.vel.add(this.acc);
         this.vel.limit(this.maxSpeed);
         this.pos.add(this.vel);
+
+        this.lifespan -= 1.5; // 寿命を減らす
+
+        // 画面外に出たら寿命をゼロにする
+        if (this.pos.x > width + this.size || this.pos.x < -this.size ||
+            this.pos.y > height + this.size || this.pos.y < -this.size) {
+            this.lifespan = 0;
+        }
     }
 
-    // 描画
     display() {
         noStroke();
+        // 寿命に応じてフェードアウト
+        let currentAlpha = map(this.lifespan, 0, 255, 0, 255);
+        this.color.setAlpha(currentAlpha);
         fill(this.color);
         ellipse(this.pos.x, this.pos.y, this.size);
-    }
-
-    // 画面の端に来たら反対側から出てくる（ループ）
-    checkEdges() {
-        if (this.pos.x > width) this.pos.x = 0;
-        if (this.pos.x < 0) this.pos.x = width;
-        if (this.pos.y > height) this.pos.y = 0;
-        if (this.pos.y < 0) this.pos.y = height;
     }
 }

--- a/style.css
+++ b/style.css
@@ -1,12 +1,17 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;700&display=swap');
+
 :root {
-    --bg-color: #1a1a1a;
-    --text-color: #e0e0e0;
-    --primary-color: #00bcd4;
-    --container-bg: #2c2c2c;
+    --bg-color: #fdfbf7;
+    --text-color: #333333;
+    --header-color: #2c3e50;
+    --primary-color: #4a69bd; /* 落ち着いた青 */
+    --container-bg: #ffffff;
+    --border-color: #dddddd;
+    --slider-bg: #e0e0e0;
 }
 
 body {
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    font-family: 'Noto Sans JP', sans-serif;
     background-color: var(--bg-color);
     color: var(--text-color);
     margin: 0;
@@ -15,6 +20,7 @@ body {
     justify-content: center;
     align-items: center;
     min-height: 100vh;
+    font-weight: 300;
 }
 
 .container {
@@ -24,53 +30,68 @@ body {
 }
 
 .header h1 {
-    color: var(--primary-color);
+    color: var(--header-color);
     margin-bottom: 10px;
+    font-weight: 700;
 }
 
 .header p {
-    font-size: 0.9em;
-    line-height: 1.6;
-    margin-bottom: 20px;
+    font-size: 1em;
+    line-height: 1.8;
+    margin-bottom: 30px;
+    color: #555;
 }
 
 #canvas-container {
-    margin-bottom: 20px;
-    display: inline-block; /* 中央揃えのため */
-    border: 1px solid #444;
-    box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+    margin-bottom: 30px;
+    /* display: inline-block; を削除 */
+    width: 100%; /* 幅を親コンテナに合わせる */
+    border: 1px solid var(--border-color);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+    border-radius: 8px;
+    overflow: hidden; /* キャンバスの角を丸めるため */
 }
 
 #controls {
     background-color: var(--container-bg);
-    padding: 20px;
+    padding: 25px;
     border-radius: 8px;
-    box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+    box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+    border: 1px solid var(--border-color);
 }
 
 .control-group {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 15px;
+    margin-bottom: 20px;
+}
+.control-group:last-child {
+    margin-bottom: 0;
 }
 
 .control-group label {
     flex-basis: 35%;
     text-align: left;
-    font-size: 0.9em;
+    font-size: 0.95em;
+    color: #444;
 }
 
 .control-group input[type="range"] {
     flex-basis: 50%;
     -webkit-appearance: none;
     appearance: none;
-    height: 8px;
-    background: #444;
+    height: 6px;
+    background: var(--slider-bg);
     border-radius: 5px;
     outline: none;
     cursor: pointer;
+    transition: opacity 0.2s;
 }
+.control-group input[type="range"]:hover {
+    opacity: 0.9;
+}
+
 
 .control-group input[type="range"]::-webkit-slider-thumb {
     -webkit-appearance: none;
@@ -79,18 +100,23 @@ body {
     height: 20px;
     background: var(--primary-color);
     border-radius: 50%;
+    border: 3px solid var(--container-bg);
+    box-shadow: 0 0 5px rgba(0,0,0,0.2);
 }
 
 .control-group input[type="range"]::-moz-range-thumb {
-    width: 20px;
-    height: 20px;
+    width: 16px; /* Firefoxではサイズ計算が異なる場合がある */
+    height: 16px;
     background: var(--primary-color);
     border-radius: 50%;
+    border: 3px solid var(--container-bg);
+    box-shadow: 0 0 5px rgba(0,0,0,0.2);
 }
 
 
 .control-group span {
     flex-basis: 10%;
     text-align: right;
-    font-weight: bold;
+    font-weight: 700;
+    color: var(--primary-color);
 }


### PR DESCRIPTION
インタラクティブアートのビジュアルと動作を全面的に刷新しました。

- **アートの動作変更:**
  - これまでの画面端でループする単調な動きを廃止。
  - 粒子が中央から放射状に広がり、時間経過や画面外で消滅する「噴水」のようなエフェクトに変更。これにより、より「広がり」を感じられるダイナミックな表現を実現しました。
  - `sketch.js`のロジックを更新し、粒子のライフサイクル管理と新しい生成メカニズムを導入しました。

- **デザインの刷新:**
  - 全体のカラースキームを、ダークテーマからクリーム色を基調とした、より洗練された明るいデザインに変更しました。
  - フォントをシンプルで読みやすい「Noto Sans JP」に変更し、サイト全体の見た目をモダンにしました。
  - UI要素（スライダー、ボタンなど）のスタイルを新しいデザインに合わせて調整し、統一感を持たせました。